### PR TITLE
feat: support create table from frontend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ rust-s3 = "0.31"
 crc32c = "0.6"
 tempdir = "0.3.5"
 etcd-client = "0.9"
+rand = "0.8.5"
 
 [[bin]]
 name = "rtstore"

--- a/src/base/mod.rs
+++ b/src/base/mod.rs
@@ -20,5 +20,6 @@ pub mod arrow_parquet_utils;
 pub mod filesystem;
 pub mod linked_list;
 pub mod log;
+pub mod mysql_utils;
 pub mod slice;
 pub mod strings;

--- a/src/base/mysql_utils.rs
+++ b/src/base/mysql_utils.rs
@@ -1,0 +1,227 @@
+//
+//
+// mysql_utils.rs
+// Copyright (C) 2022 rtstore.io Author imotai <codego.me@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use crate::error::{RTStoreError, Result};
+use crate::proto::rtstore_base_proto::{RtStoreColumnDesc, RtStoreSchemaDesc, RtStoreType};
+use arrow::array::{
+    BooleanArray, Float32Array, Float64Array, Int16Array, Int32Array, Int64Array, Int8Array,
+    StringArray, TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray,
+    TimestampSecondArray,
+};
+use arrow::datatypes::{DataType, Schema, SchemaRef, TimeUnit};
+use arrow::record_batch::RecordBatch;
+use msql_srv::Column as MySQLColumn;
+use msql_srv::ColumnFlags;
+use msql_srv::ColumnType;
+use msql_srv::OkResponse;
+use msql_srv::QueryResultWriter;
+use sqlparser::ast::{ColumnDef, ColumnOption, DataType as SPDataType};
+uselog!(info, warn);
+
+macro_rules! type_mapping {
+    ($columns:ident, $right_type:ident, $field:ident) => {
+        let col = MySQLColumn {
+            table: "".to_string(),
+            column: $field.name().to_string(),
+            coltype: ColumnType::$right_type,
+            colflags: ColumnFlags::empty(),
+        };
+        $columns.push(col);
+    };
+}
+
+pub fn record_batch_schema_to_mysql_schema(schema: &SchemaRef) -> Result<Vec<MySQLColumn>> {
+    let mut mysql_cols = vec![];
+    for field in schema.fields() {
+        // all mysql types go to
+        // https://github.com/blackbeam/rust_mysql_common/blob/master/src/constants.rs#L587
+        // all parquet types go to
+        // https://github.com/apache/arrow-rs/blob/master/arrow/src/datatypes/datatype.rs#L43
+        match field.data_type() {
+            DataType::Boolean => {
+                type_mapping!(mysql_cols, MYSQL_TYPE_BIT, field);
+            }
+            DataType::Int8 => {
+                type_mapping!(mysql_cols, MYSQL_TYPE_TINY, field);
+            }
+            DataType::Int16 => {
+                type_mapping!(mysql_cols, MYSQL_TYPE_SHORT, field);
+            }
+            DataType::Int32 => {
+                type_mapping!(mysql_cols, MYSQL_TYPE_LONG, field);
+            }
+            DataType::Int64 => {
+                type_mapping!(mysql_cols, MYSQL_TYPE_LONGLONG, field);
+            }
+            DataType::Float32 => {
+                type_mapping!(mysql_cols, MYSQL_TYPE_FLOAT, field);
+            }
+            DataType::Float64 => {
+                type_mapping!(mysql_cols, MYSQL_TYPE_FLOAT, field);
+            }
+            DataType::Timestamp(..) => {
+                type_mapping!(mysql_cols, MYSQL_TYPE_TIMESTAMP, field);
+            }
+            DataType::Utf8 => {
+                type_mapping!(mysql_cols, MYSQL_TYPE_STRING, field);
+            }
+            DataType::Decimal(..) => {
+                type_mapping!(mysql_cols, MYSQL_TYPE_DECIMAL, field);
+            }
+            _ => {
+                return Err(RTStoreError::TableSchemaConvertError(0));
+            }
+        }
+    }
+    Ok(mysql_cols)
+}
+
+macro_rules! mysql_data_convert {
+    ($row_idx:ident, $column_idx:ident, $data_type:ident,
+     $writer:ident, $record_batch:ident) => {
+        let arr = $record_batch
+            .column($column_idx)
+            .as_any()
+            .downcast_ref::<$data_type>()
+            .expect("Failed to downcast");
+        $writer
+            .write_col(arr.value($row_idx))
+            .expect("fail to write col to writer");
+    };
+}
+
+pub fn write_batch_to_resultset<'a, W: std::io::Write + Send>(
+    record_batches: &[RecordBatch],
+    results: QueryResultWriter<'a, W>,
+) -> Result<()> {
+    if record_batches.is_empty() {
+        results.completed(OkResponse::default()).unwrap();
+        return Ok(());
+    }
+    let schema = record_batches[0].schema();
+    let mysql_schema = record_batch_schema_to_mysql_schema(&schema)?;
+    let mut rw = results.start(&mysql_schema)?;
+    for batch in record_batches {
+        for i in 0..batch.num_rows() {
+            for j in 0..batch.num_columns() {
+                let data_type = schema.field(j).data_type();
+                match data_type {
+                    DataType::Int8 => {
+                        mysql_data_convert!(i, j, Int8Array, rw, batch);
+                    }
+                    DataType::Int16 => {
+                        mysql_data_convert!(i, j, Int16Array, rw, batch);
+                    }
+                    DataType::Int32 => {
+                        mysql_data_convert!(i, j, Int32Array, rw, batch);
+                    }
+                    DataType::Int64 => {
+                        mysql_data_convert!(i, j, Int64Array, rw, batch);
+                    }
+                    DataType::Float32 => {
+                        mysql_data_convert!(i, j, Float32Array, rw, batch);
+                    }
+                    DataType::Float64 => {
+                        mysql_data_convert!(i, j, Float64Array, rw, batch);
+                    }
+                    DataType::Utf8 => {
+                        mysql_data_convert!(i, j, StringArray, rw, batch);
+                    }
+                    DataType::Timestamp(tu, _) => match tu {
+                        TimeUnit::Second => {
+                            let arr = batch
+                                .column(j)
+                                .as_any()
+                                .downcast_ref::<TimestampSecondArray>()
+                                .expect("Failed to downcast");
+                            let v = arr.value_as_datetime(i);
+                            rw.write_col(v)?;
+                        }
+                        TimeUnit::Millisecond => {
+                            let arr = batch
+                                .column(j)
+                                .as_any()
+                                .downcast_ref::<TimestampMillisecondArray>()
+                                .expect("Failed to downcast");
+                            let v = arr.value_as_datetime(i);
+                            rw.write_col(v)?;
+                        }
+                        TimeUnit::Microsecond => {
+                            let arr = batch
+                                .column(j)
+                                .as_any()
+                                .downcast_ref::<TimestampMicrosecondArray>()
+                                .expect("Failed to downcast");
+                            let v = arr.value_as_datetime(i);
+                            rw.write_col(v)?;
+                        }
+                        TimeUnit::Nanosecond => {
+                            let arr = batch
+                                .column(j)
+                                .as_any()
+                                .downcast_ref::<TimestampNanosecondArray>()
+                                .expect("Failed to downcast");
+                            let v = arr.value_as_datetime(i);
+                            rw.write_col(v)?;
+                        }
+                    },
+                    _ => {
+                        return Err(RTStoreError::TableSchemaConvertError(0));
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+pub fn sql_to_table_desc(columns: &Vec<ColumnDef>) -> Result<RtStoreSchemaDesc> {
+    let mut rtstore_columns: Vec<RtStoreColumnDesc> = Vec::new();
+    for column in columns {
+        let rtstore_type = match column.data_type {
+            SPDataType::TinyInt(_) => Ok(RtStoreType::KTinyInt),
+            SPDataType::SmallInt(_) => Ok(RtStoreType::KSmallInt),
+            SPDataType::Int(_) => Ok(RtStoreType::KInt),
+            SPDataType::BigInt(_) => Ok(RtStoreType::KBigInt),
+            SPDataType::Float(_) => Ok(RtStoreType::KFloat),
+            SPDataType::Timestamp => Ok(RtStoreType::KTimestampMillsSecond),
+            SPDataType::Varchar(_) | SPDataType::String => Ok(RtStoreType::KStringUtf8),
+            SPDataType::Double => Ok(RtStoreType::KDouble),
+            SPDataType::Decimal(..) => Ok(RtStoreType::KDecimal),
+            _ => {
+                warn!("{} is not supported currently", column);
+                Err(RTStoreError::TableSchemaConvertError(0))
+            }
+        }?;
+        let mut null_allowed = true;
+
+        if column.options.len() > 0 && ColumnOption::NotNull == column.options[0].option {
+            null_allowed = false;
+        }
+        let rtstore_column = RtStoreColumnDesc {
+            name: column.name.value.to_string(),
+            ctype: rtstore_type as i32,
+            null_allowed,
+        };
+        rtstore_columns.push(rtstore_column);
+    }
+    Ok(RtStoreSchemaDesc {
+        columns: rtstore_columns,
+        version: 1,
+    })
+}

--- a/src/cmd/rtstore.rs
+++ b/src/cmd/rtstore.rs
@@ -231,10 +231,10 @@ async fn start_frontend_server(cmd: &Commands) -> Result<(), Box<dyn std::error:
                 build_memory_node_sdk(&meta_store).await,
             ) {
                 let addr = format!("{}:{}", ns, port);
-                info!("etcd {} {}", etcd_cluster, etcd_root_path);
                 info!("start frontend node on addr {}", addr);
                 let listener = TcpListener::bind(addr).await.unwrap();
                 let arc_store = Arc::new(meta_store);
+                arc_store.get_table_metas().await;
                 arc_store.subscribe_table_events().await;
                 let handler =
                     mysql_handler::MySQLHandler::new(meta_node_sdk, memory_node_sdk, arc_store);

--- a/src/cmd/rtstore.rs
+++ b/src/cmd/rtstore.rs
@@ -19,12 +19,19 @@
 //
 #[macro_use(uselog)]
 extern crate uselog_rs;
-use rtstore::proto::rtstore_base_proto::{RtStoreNode, RtStoreNodeType};
+use msql_srv::*;
+use tokio::net::TcpListener;
 
+use etcd_client::Client;
+use rtstore::error::RTStoreError;
+use rtstore::frontend_node::mysql::mysql_handler;
 use rtstore::memory_node::memory_node_impl::{MemoryNodeConfig, MemoryNodeImpl};
 use rtstore::meta_node::meta_server::{MetaConfig, MetaServiceImpl};
+use rtstore::proto::rtstore_base_proto::{RtStoreNode, RtStoreNodeType};
 use rtstore::proto::rtstore_memory_proto::memory_node_server::MemoryNodeServer;
 use rtstore::proto::rtstore_meta_proto::meta_server::MetaServer;
+use rtstore::sdk::meta_node_sdk::MetaNodeSDK;
+use rtstore::store::meta_store::{MetaStore, MetaStoreConfig, MetaStoreType};
 use tonic::transport::Server;
 extern crate pretty_env_logger;
 uselog!(debug, info, warn);
@@ -62,6 +69,18 @@ enum Commands {
         binlog_root_dir: String,
         #[clap(required = true)]
         tmp_root_dir: String,
+        #[clap(required = true)]
+        etcd_cluster: String,
+        #[clap(required = true)]
+        etcd_root_path: String,
+        #[clap(required = true)]
+        ns: String,
+    },
+    /// Start Frontend Node Server
+    #[clap(arg_required_else_help = true)]
+    FrontendNode {
+        #[clap(required = true)]
+        port: i32,
         #[clap(required = true)]
         etcd_cluster: String,
         #[clap(required = true)]
@@ -148,6 +167,69 @@ async fn start_metaserver(cmd: &Commands) -> Result<(), Box<dyn std::error::Erro
     Ok(())
 }
 
+async fn build_meta_node_sdk(
+    etcd_cluster: &str,
+    etcd_root_path: &str,
+) -> rtstore::error::Result<MetaNodeSDK> {
+    let meta_store_config = MetaStoreConfig {
+        store_type: MetaStoreType::ImmutableMetaStore,
+        root_path: etcd_root_path.to_string(),
+    };
+    let etcd_cluster_endpoints: Vec<&str> = etcd_cluster.split(",").collect();
+    let client = match Client::connect(etcd_cluster_endpoints, None).await {
+        Ok(client) => Ok(client),
+        Err(_) => Err(RTStoreError::NodeRPCInvalidEndpointError {
+            name: "etcd".to_string(),
+        }),
+    }?;
+    let meta_store = MetaStore::new(client, meta_store_config);
+    let nodes = meta_store.get_nodes(RtStoreNodeType::KMetaNode).await?;
+    if nodes.is_empty() {
+        return Err(RTStoreError::MetaStoreNotFoundErr);
+    }
+    let meta_addr = format!("http://{}:{}", nodes[0].ns, nodes[0].port);
+    info!("connect to meta node {}", meta_addr);
+    match MetaNodeSDK::connect(&meta_addr).await {
+        Ok(sdk) => Ok(sdk),
+        Err(e) => Err(RTStoreError::NodeRPCError(
+            format!("fail to connect meta node for err {}", e).to_string(),
+        )),
+    }
+}
+
+async fn start_frontend_server(cmd: &Commands) -> Result<(), Box<dyn std::error::Error>> {
+    if let Commands::FrontendNode {
+        port,
+        etcd_cluster,
+        etcd_root_path,
+        ns,
+    } = cmd
+    {
+        if let Ok(sdk) = build_meta_node_sdk(etcd_cluster, etcd_root_path).await {
+            let addr = format!("{}:{}", ns, port);
+            info!("etcd {} {}", etcd_cluster, etcd_root_path);
+            info!("start frontend node on addr {}", addr);
+            let listener = TcpListener::bind(addr).await.unwrap();
+            let handler = mysql_handler::MySQLHandler::new(sdk);
+            loop {
+                let (socket, _) = listener.accept().await.unwrap();
+                let new_handler = handler.clone();
+                tokio::spawn(async move {
+                    let result = AsyncMysqlIntermediary::run_on(new_handler, socket).await;
+                    match result {
+                        Ok(_) => {}
+                        Err(e) => {
+                            warn!("fail to process incoming connection with e {}", e);
+                        }
+                    }
+                });
+            }
+        }
+    }
+
+    Ok(())
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     setup_log();
@@ -155,5 +237,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     match args.command {
         Commands::Meta { .. } => start_metaserver(&args.command).await,
         Commands::MemoryNode { .. } => start_memory_node(&args.command).await,
+        Commands::FrontendNode { .. } => start_frontend_server(&args.command).await,
     }
 }

--- a/src/frontend_node/mod.rs
+++ b/src/frontend_node/mod.rs
@@ -16,3 +16,4 @@
 // limitations under the License.
 //
 
+pub mod mysql;

--- a/src/frontend_node/mysql/interruptible_parser.rs
+++ b/src/frontend_node/mysql/interruptible_parser.rs
@@ -1,0 +1,76 @@
+//
+//
+// interruptible_parser.rs
+// Copyright (C) 2022 peasdb.ai Author imotai <codego.me@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use crate::error::{RTStoreError, Result};
+use sqlparser::ast::Statement;
+use sqlparser::dialect::Dialect;
+use sqlparser::keywords::Keyword;
+use sqlparser::parser::*;
+use sqlparser::tokenizer::{Token, Tokenizer};
+
+pub struct InterruptibleParser<'a> {
+    // sql parser
+    parser: Parser<'a>,
+    // keyword to show what's the type of sql, Some types like
+    // * Create , create table or create database
+    // * Insert , insert data
+    // * Select , query data from table or system variables
+    // * Set, update system variables
+    // * Show, show system variables
+    // More go to https://github.com/sqlparser-rs/sqlparser-rs/blob/main/src/parser.rs#L156
+    keyword: Option<Keyword>,
+    sql: &'a str,
+}
+
+impl<'a> InterruptibleParser<'a> {
+    pub fn new(dialect: &'a dyn Dialect, sql: &'a str) -> Result<Self> {
+        let mut tokenizer = Tokenizer::new(dialect, sql);
+        let tokens = tokenizer.tokenize()?;
+        Ok(Self {
+            parser: Parser::new(tokens, dialect),
+            keyword: None,
+            sql,
+        })
+    }
+
+    pub fn next_keyword(&mut self) -> Result<Keyword> {
+        match self.keyword {
+            Some(k) => Ok(k),
+            None => match self.parser.next_token() {
+                Token::Word(w) => {
+                    let cloned_kw = w.keyword;
+                    self.keyword = Some(w.keyword);
+                    Ok(cloned_kw)
+                }
+                _ => Result::Err(RTStoreError::SQLParseError(format!(
+                    "fail to parse {}",
+                    self.sql
+                ))),
+            },
+        }
+    }
+
+    pub fn prev_token(&mut self) {
+        self.parser.prev_token();
+    }
+
+    pub fn parse_left(&mut self) -> Result<Statement> {
+        let statement = self.parser.parse_statement()?;
+        Ok(statement)
+    }
+}

--- a/src/frontend_node/mysql/mod.rs
+++ b/src/frontend_node/mysql/mod.rs
@@ -16,3 +16,6 @@
 // limitations under the License.
 //
 
+mod interruptible_parser;
+pub mod mysql_handler;
+mod sql_handler;

--- a/src/frontend_node/mysql/mysql_handler.rs
+++ b/src/frontend_node/mysql/mysql_handler.rs
@@ -1,0 +1,159 @@
+//
+//
+// mysql_handler.rs
+// Copyright (C) 2022 Author zombie <zombie@zombie-ub2104>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use super::sql_handler::SQLExecutor;
+use crate::sdk::meta_node_sdk::MetaNodeSDK;
+use async_trait::async_trait;
+use msql_srv::AsyncMysqlShim;
+use msql_srv::InitWriter;
+use msql_srv::OkResponse;
+use msql_srv::ParamParser;
+use msql_srv::QueryResultWriter;
+use msql_srv::StatementMetaWriter;
+use rand::RngCore;
+use std::io::{Error, Result};
+uselog!(debug, info, warn);
+
+pub struct MySQLHandler {
+    version: String,
+    id: u32,
+    salt: [u8; 20],
+    sql_executor: SQLExecutor,
+}
+
+impl Clone for MySQLHandler {
+    fn clone(&self) -> Self {
+        let mut bs = vec![0u8; 20];
+        let mut rng = rand::thread_rng();
+        rng.fill_bytes(bs.as_mut());
+        let mut scramble: [u8; 20] = [0; 20];
+        for i in 0..20 {
+            scramble[i] = bs[i];
+            if scramble[i] == b'\0' || scramble[i] == b'$' {
+                scramble[i] += 1;
+            }
+        }
+        Self {
+            version: self.version.clone(),
+            salt: scramble,
+            id: self.id + 1,
+            sql_executor: self.sql_executor.clone(),
+        }
+    }
+}
+
+impl MySQLHandler {
+    pub fn new(sdk: MetaNodeSDK) -> Self {
+        Self {
+            version: "8.0.26-rtstore".to_string(),
+            id: 0,
+            salt: [0 as u8; 20],
+            sql_executor: SQLExecutor::new(sdk),
+        }
+    }
+}
+
+#[async_trait]
+impl<W: std::io::Write + Send> AsyncMysqlShim<W> for MySQLHandler {
+    type Error = Error;
+
+    fn version(&self) -> &str {
+        self.version.as_str()
+    }
+
+    fn connect_id(&self) -> u32 {
+        self.id
+    }
+
+    fn default_auth_plugin(&self) -> &str {
+        "mysql_native_password"
+    }
+
+    fn auth_plugin_for_username(&self, _user: &[u8]) -> &str {
+        "mysql_native_password"
+    }
+
+    fn salt(&self) -> [u8; 20] {
+        self.salt
+    }
+
+    async fn authenticate(
+        &self,
+        _auth_plugin: &str,
+        _username: &[u8],
+        _salt: &[u8],
+        _auth_data: &[u8],
+    ) -> bool {
+        true
+    }
+
+    async fn authenticate_with_db(
+        &self,
+        _auth_plugin: &str,
+        _username: &[u8],
+        _salt: &[u8],
+        _auth_data: &[u8],
+        _db: &[u8],
+    ) -> bool {
+        true
+    }
+
+    async fn on_prepare<'a>(
+        &'a mut self,
+        query: &'a str,
+        _writer: StatementMetaWriter<'a, W>,
+    ) -> Result<()> {
+        info!("on prepare query {}", query);
+        Ok(())
+    }
+
+    async fn on_execute<'a>(
+        &'a mut self,
+        id: u32,
+        _param: ParamParser<'a>,
+        _writer: QueryResultWriter<'a, W>,
+    ) -> Result<()> {
+        info!("on exec id {}", id);
+        Ok(())
+    }
+
+    async fn on_close<'a>(&'a mut self, id: u32)
+    where
+        W: 'async_trait,
+    {
+        info!("on close id {}", id);
+    }
+
+    async fn on_query<'a>(
+        &'a mut self,
+        sql: &'a str,
+        results: QueryResultWriter<'a, W>,
+    ) -> Result<()> {
+        self.sql_executor.execute(sql, None).await.unwrap();
+        results.completed(OkResponse::default())?;
+        Ok(())
+    }
+
+    async fn on_init<'a>(
+        &'a mut self,
+        database_name: &'a str,
+        writer: InitWriter<'a, W>,
+    ) -> Result<()> {
+        writer.ok()
+    }
+}

--- a/src/frontend_node/mysql/mysql_handler.rs
+++ b/src/frontend_node/mysql/mysql_handler.rs
@@ -17,7 +17,9 @@
 //
 
 use super::sql_handler::SQLExecutor;
+use crate::sdk::memory_node_sdk::MemoryNodeSDK;
 use crate::sdk::meta_node_sdk::MetaNodeSDK;
+use crate::store::meta_store::MetaStore;
 use async_trait::async_trait;
 use msql_srv::AsyncMysqlShim;
 use msql_srv::InitWriter;
@@ -27,6 +29,7 @@ use msql_srv::QueryResultWriter;
 use msql_srv::StatementMetaWriter;
 use rand::RngCore;
 use std::io::{Error, Result};
+use std::sync::Arc;
 uselog!(debug, info, warn);
 
 pub struct MySQLHandler {
@@ -58,12 +61,16 @@ impl Clone for MySQLHandler {
 }
 
 impl MySQLHandler {
-    pub fn new(sdk: MetaNodeSDK) -> Self {
+    pub fn new(
+        sdk: MetaNodeSDK,
+        memory_node_sdk: MemoryNodeSDK,
+        meta_store: Arc<MetaStore>,
+    ) -> Self {
         Self {
             version: "8.0.26-rtstore".to_string(),
             id: 0,
             salt: [0 as u8; 20],
-            sql_executor: SQLExecutor::new(sdk),
+            sql_executor: SQLExecutor::new(sdk, meta_store, memory_node_sdk),
         }
     }
 }

--- a/src/frontend_node/mysql/mysql_session.rs
+++ b/src/frontend_node/mysql/mysql_session.rs
@@ -1,6 +1,6 @@
 //
 //
-// lib.rs
+// mysql_session.rs
 // Copyright (C) 2022 rtstore.io Author imotai <codego.me@gmail.com>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,14 +16,8 @@
 // limitations under the License.
 //
 
-#[macro_use(uselog)]
-extern crate uselog_rs;
-pub mod base;
-pub mod codec;
-pub mod error;
-pub mod frontend_node;
-pub mod memory_node;
-pub mod meta_node;
-pub mod proto;
-pub mod sdk;
-pub mod store;
+
+pub struct MySQLSession {
+
+
+}

--- a/src/frontend_node/mysql/mysql_vars.rs
+++ b/src/frontend_node/mysql/mysql_vars.rs
@@ -1,0 +1,74 @@
+//
+//
+// mysql_vars.rs
+// Copyright (C) 2022 peasdb.ai Author imotai <codego.me@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+use datafusion::error::Result as DResult;
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::*;
+uselog!(debug, info, warn);
+
+pub struct MySQLVars {
+    pub global_sys_vars: HashMap<String, String>,
+    pub session_sys_vars: HashMap<String, String>,
+}
+
+impl MySQLVars {
+    pub fn new(config_path: &str) -> DResult<Self> {
+        let fd = File::open(config_path).unwrap();
+        let reader = BufReader::new(fd);
+        let mut vars: HashMap<String, String> = HashMap::new();
+        for line_ret in reader.lines() {
+            let line = line_ret.unwrap();
+            let kv: Vec<&str> = line.split('\t').collect();
+            debug!("input line {} and split len {}", line, kv.len());
+            if kv.len() != 2 {
+                warn!("invalid line format {}", line);
+                continue;
+            }
+            match kv[1] {
+                "ON" => {
+                    vars.insert(kv[0].to_string(), "1".to_string());
+                }
+                "OFF" => {
+                    vars.insert(kv[0].to_string(), "0".to_string());
+                }
+                _ => {
+                    vars.insert(kv[0].to_string(), kv[1].to_string());
+                }
+            }
+        }
+        Ok(MySQLVars {
+            global_sys_vars: vars.clone(),
+            session_sys_vars: vars.clone(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn it_test_load_config() -> DResult<()> {
+        let path: &str = "./static/vars.txt";
+        let mysql_vars = MySQLVars::new(path)?;
+        assert_eq!(
+            true,
+            mysql_vars.global_sys_vars.contains_key("wait_timeout")
+        );
+        Ok(())
+    }
+}

--- a/src/frontend_node/mysql/sql_handler.rs
+++ b/src/frontend_node/mysql/sql_handler.rs
@@ -1,0 +1,96 @@
+//
+//
+// sql_handler.rs
+// Copyright (C) 2022 rtstore.io Author imotai <codego.me@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use super::interruptible_parser::*;
+use crate::base::mysql_utils;
+use crate::proto::rtstore_base_proto::{RtStoreNodeType, RtStoreTableDesc};
+use arrow::record_batch::RecordBatch;
+use async_trait::async_trait;
+use sqlparser::{
+    ast::{ColumnDef, Statement as SQLStatement, UnaryOperator},
+    dialect::{keywords::Keyword, MySqlDialect},
+};
+use std::sync::{Arc, Mutex};
+uselog!(debug, info, warn);
+use crate::error::{RTStoreError, Result};
+use crate::sdk::meta_node_sdk::MetaNodeSDK;
+use parquet::record::Field;
+
+pub struct SQLResult {
+    pub effected_rows: usize,
+}
+
+#[derive(Clone)]
+pub struct SQLExecutor {
+    meta_sdk: MetaNodeSDK,
+}
+
+unsafe impl Send for SQLExecutor {}
+unsafe impl Sync for SQLExecutor {}
+
+impl SQLExecutor {
+    pub fn new(meta_sdk: MetaNodeSDK) -> Self {
+        Self { meta_sdk }
+    }
+
+    pub fn parse_sql(&self, sql: &str) -> Result<(Keyword, SQLStatement)> {
+        let dialect = MySqlDialect {};
+        let mut parser = InterruptibleParser::new(&dialect, sql)?;
+        let keyword = parser.next_keyword()?;
+        parser.prev_token();
+        let statement = parser.parse_left()?;
+        Ok((keyword, statement))
+    }
+
+    fn build_full_name(&self, table_name: &str, db: Option<String>) -> Vec<String> {
+        if let Some(d) = db {
+            vec![d, table_name.to_string()]
+        } else {
+            vec![table_name.to_string()]
+        }
+    }
+
+    async fn handle_create_table(
+        &self,
+        table_full_name: Vec<String>,
+        columns: &Vec<ColumnDef>,
+    ) -> Result<()> {
+        let schema_desc = mysql_utils::sql_to_table_desc(columns)?;
+        let table_desc = RtStoreTableDesc {
+            names: table_full_name,
+            schema: Some(schema_desc),
+            partition_desc: None,
+        };
+        if let Err(e) = self.meta_sdk.create_table(table_desc).await {
+            warn!("fail  to create table for err {}", e);
+        }
+        Ok(())
+    }
+
+    pub async fn execute(&self, sql: &str, db: Option<String>) -> Result<SQLResult> {
+        let (keyword, statement) = self.parse_sql(sql)?;
+        match (keyword, statement) {
+            (Keyword::CREATE, SQLStatement::CreateTable { name, columns, .. }) => {
+                let table_full_name = self.build_full_name(&name.0[0].value, db);
+                self.handle_create_table(table_full_name, &columns).await?;
+                Ok(SQLResult { effected_rows: 1 })
+            }
+            (_, _) => Ok(SQLResult { effected_rows: 0 }),
+        }
+    }
+}

--- a/src/memory_node/memory_node_impl.rs
+++ b/src/memory_node/memory_node_impl.rs
@@ -236,7 +236,7 @@ impl MemoryNodeImpl {
         // TODO avoid start compaction repeated
         tokio::task::spawn(async move {
             loop {
-                sleep(Duration::from_millis(1000)).await;
+                sleep(Duration::from_millis(1000 * 10)).await;
                 let cell_opt = match local_state.lock() {
                     Ok(node_state) => node_state.get_cell(&local_table_id, pid),
                     Err(_) => None,

--- a/src/meta_node/table.rs
+++ b/src/meta_node/table.rs
@@ -16,35 +16,27 @@
 // limitations under the License.
 //
 
-//use crate::base::arrow_parquet_utils::*;
+use crate::base::arrow_parquet_utils::*;
 use crate::error::{RTStoreError, Result};
 use crate::proto::rtstore_base_proto::RtStoreTableDesc;
-//use arrow::datatypes::SchemaRef;
-//use std::ops::Range;
-//use std::sync::Arc;
+use arrow::datatypes::SchemaRef;
 uselog!(info);
 
 /// the smallest data unit for table store
-//pub struct Cell {
-//    range: Range<u64>,
-//    partition_index: usize,
-//    num_rows: u64,
-//}
-//
-//pub struct Partition {
-//    partition_index: usize,
-//    num_rows: u64,
-//    cells: Vec<Cell>,
-//}
+pub struct Partition {
+    partition_index: usize,
+    num_rows: u64,
+    endpoint: Option<String>,
+}
 
 pub struct Table {
     // name of table like db1.user
-//id: String,
-// schema for table
-//schema: SchemaRef,
-// rtstore table description
-//table_desc: Arc<RtStoreTableDesc>,
-//partitions: Vec<Partition>,
+    id: String,
+    //schema for table
+    schema: SchemaRef,
+    // rtstore table description
+    table_desc: RtStoreTableDesc,
+    partitions: Vec<Partition>,
 }
 
 impl Table {
@@ -61,29 +53,28 @@ impl Table {
     pub fn new(table_desc: &RtStoreTableDesc) -> Result<Self> {
         let id = Self::gen_id(table_desc)?;
         info!("gen a new table id {}", id);
-        //let schema = match &table_desc.schema {
-        //    Some(s) => Ok(s),
-        //    _ => Err(RTStoreError::TableSchemaInvalidError {
-        //        name: id.to_string(),
-        //    }),
-        //}?;
-        //let arrow_schema_ref = table_desc_to_arrow_schema(schema)?;
-        //let cell = Cell {
-        //    range: std::ops::Range { start: 1, end: 2 },
-        //    partition_index: 1,
-        //    num_rows: 10,
-        //};
-        //let partition = Partition {
-        //    partition_index: 1,
-        //    num_rows: 100,
-        //    cells: vec![cell],
-        //};
-        //let table = Self {
-        //  id,
-        //   schema: arrow_schema_ref,
-        //    table_desc: Arc::new(table_desc.clone()),
-        //    partitions: vec![partition],
-        //};
-        Ok(Self {})
+        let schema = match &table_desc.schema {
+            Some(s) => Ok(s),
+            _ => Err(RTStoreError::TableSchemaInvalidError {
+                name: id.to_string(),
+            }),
+        }?;
+        let arrow_schema_ref = table_desc_to_arrow_schema(schema)?;
+        let partition = Partition {
+            partition_index: 1,
+            num_rows: 100,
+            endpoint: None,
+        };
+        Ok(Self {
+            id,
+            schema: arrow_schema_ref,
+            table_desc: table_desc.clone(),
+            partitions: vec![partition],
+        })
+    }
+
+    #[inline]
+    pub fn get_table_desc<'a>(&'a self) -> &'a RtStoreTableDesc {
+        &self.table_desc
     }
 }

--- a/src/sdk/memory_node_sdk.rs
+++ b/src/sdk/memory_node_sdk.rs
@@ -34,6 +34,15 @@ pub struct MemoryNodeSDK {
     client: Arc<MemoryNodeClient<tonic::transport::Channel>>,
 }
 
+impl Clone for MemoryNodeSDK {
+    fn clone(&self) -> Self {
+        Self {
+            endpoint: self.endpoint.to_string(),
+            client: self.client.clone(),
+        }
+    }
+}
+
 impl MemoryNodeSDK {
     pub async fn connect(endpoint: &str) -> std::result::Result<Self, tonic::transport::Error> {
         // create a new client connection

--- a/src/store/meta_store.rs
+++ b/src/store/meta_store.rs
@@ -213,9 +213,10 @@ mod tests {
             port: 8989,
         };
         assert!(meta_store.add_node(&rtstore_node).await.is_ok());
-        let nodes = meta_store.get_nodes(rtstore_node.node_type)?;
+        let nodes = meta_store.get_nodes(RtStoreNodeType::KComputeNode).await?;
         assert_eq!(1, nodes.len());
         assert_eq!(rtstore_node.ns, nodes[0].ns);
+        Ok(())
     }
 
     fn create_simple_table_desc(tname: &str) -> RtStoreTableDesc {


### PR DESCRIPTION
Now this PR can pass a simple case like
```
# start a meta node
RUST_LOG=info ./target/debug/rtstore meta 9191 http://127.0.0.1:2379 /rtstore 127.0.0.1
# start a memory node
RUST_LOG=info ./target/debug/rtstore memory-node 9791 /tmp/binlog /tmp/test http://127.0.0.1:2379 /rtstore 127.0.0.1
# start a frontend node
RUST_LOG=info ./target/debug/rtstore frontend-node 9292 http://127.0.0.1:2379 /rtstore 127.0.0.1
# connect to frontend node with mysql cli
mysql -uroot -h127.0.0.1 -P 9292 -p
>create table t9 (col1 int);
>insert into t9 values(1);
```
Some required environments
* etcd
* aws local